### PR TITLE
bugfix/clear service instance params before set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3
+
+- clear service instance params before set
+
 ## 0.2.2
 
 - Remove Sails.init in base.rb (#5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sails (0.2.2)
+    sails (0.2.3)
       activesupport (> 3.2.0)
       thor
       thrift (>= 0.9.0)

--- a/lib/sails/service/interface.rb
+++ b/lib/sails/service/interface.rb
@@ -28,6 +28,7 @@ module Sails
       end
 
       def set_params_with_method_args(instance, method_name, args)
+        instance.params.clear
         method_args = instance.method(method_name.to_sym).parameters.map { |arg| arg[1] }
         instance.params[:method_name] = method_name
         method_args.each_with_index do |arg, idx|

--- a/lib/sails/version.rb
+++ b/lib/sails/version.rb
@@ -1,5 +1,5 @@
 module Sails
   def self.version
-    "0.2.2"
+    "0.2.3"
   end
 end

--- a/spec/service/interface_spec.rb
+++ b/spec/service/interface_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe 'Service' do
+  describe 'Interface' do
+    class SimpleBaseTestService < Sails::Service::Base
+      def bar(a, b)
+      end
+
+      def foo(c, d)
+        
+      end
+    end
+
+    module Sails
+      module Service
+        class Interface
+          attr_accessor :services
+
+          def initialize
+            @services = []
+            @services << SimpleBaseTestService.new
+            define_service_methods!
+          end
+        end
+      end
+    end
+
+    let(:interface) { Sails::Service::Interface.new }
+
+    describe 'set params' do
+      it "should set val" do
+        simple = interface.services.first
+        interface.bar(1, 2)
+        expect(simple.params.size).to eq(3)
+        expect(simple.params[:method_name]).to eq('bar')
+        expect(simple.params[:a]).to eq(1)
+        expect(simple.params[:b]).to eq(2)
+      end
+      it "shoud clear val before set" do
+        simple = interface.services.first
+        interface.bar(1, 2)
+        interface.foo(3, 4)
+        expect(simple.params.size).to eq(3)
+        expect(simple.params[:method_name]).to eq('foo')
+        expect(simple.params[:c]).to eq(3)
+        expect(simple.params[:d]).to eq(4)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Interface这个类，每个service只实例化一次后放到@services，每个service的params又是实例变量，每次set_params_with_method_args时需要把params clear掉，不然会带着之前请求的参数。