### PR TITLE
bugfix/start_thread_pool_server undefined Setting error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4
+
+- fix start_thread_pool_server undefined Setting error
+
 ## 0.2.3
 
 - clear service instance params before set

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sails (0.2.3)
+    sails (0.2.4)
       activesupport (> 3.2.0)
       thor
       thrift (>= 0.9.0)
@@ -9,17 +9,16 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.6)
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    concurrent-ruby (1.0.2)
     dalli (2.7.1)
     diff-lcs (1.2.5)
     i18n (0.7.0)
-    json (1.8.3)
-    minitest (5.9.1)
+    minitest (5.10.1)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
@@ -32,7 +31,7 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
-    thor (0.19.1)
+    thor (0.19.4)
     thread_safe (0.3.5)
     thrift (0.9.3.0)
     tzinfo (1.2.2)

--- a/lib/sails/base.rb
+++ b/lib/sails/base.rb
@@ -207,7 +207,7 @@ module Sails
       @server = ::Thrift::ThreadPoolServer.new(processor, transport, transport_factory, protocol_factory, config.thread_size)
 
       logger.info "Boot on: #{Sails.root}"
-      logger.info "[#{Time.now}] Starting the Sails with ThreadPool size: #{Setting.pool_size}..."
+      logger.info "[#{Time.now}] Starting the Sails with ThreadPool size: #{config.thread_size}..."
       logger.info "serve: 127.0.0.1:#{config.thread_port}"
 
       begin

--- a/lib/sails/version.rb
+++ b/lib/sails/version.rb
@@ -1,5 +1,5 @@
 module Sails
   def self.version
-    "0.2.3"
+    "0.2.4"
   end
 end


### PR DESCRIPTION
发现用NonblockingServer的时候有点问题，client端close链接之后，server端不会关闭链接（没回发Fin给客户端），导致服务端的大量TCP链接一直在CLOST_WAIT状态。改用ThreadPoolServer就没有这个问题。感觉应该是thrift这个gem的bug，还没时间仔细研究。
先把这个起ThreadPoolServer的bug改了吧。。